### PR TITLE
Feat/telegram bot

### DIFF
--- a/lambda/telegram-notifier/index.ts
+++ b/lambda/telegram-notifier/index.ts
@@ -1,0 +1,79 @@
+import {PrismaClient} from "@prisma/client";
+
+const TELEGRAM_API_BASE = "https://api.telegram.org/bot";
+
+// Lambda cold start 시 1회 생성, warm 상태에서 재사용
+const prisma = new PrismaClient();
+
+// 텔레그램 메시지 발송
+async function sendMessage(chatId: string, text: string): Promise<boolean> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    console.error("TELEGRAM_BOT_TOKEN 미설정");
+    return false;
+  }
+
+  try {
+    const response = await fetch(`${TELEGRAM_API_BASE}${token}/sendMessage`, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        parse_mode: "HTML",
+      }),
+    });
+
+    if (!response.ok) {
+      console.error("메시지 발송 실패:", await response.text());
+      return false;
+    }
+    return true;
+  } catch (error) {
+    console.error("메시지 발송 오류:", error);
+    return false;
+  }
+}
+
+// 현재 KST 시각을 "HH:mm" 형식으로 반환
+function getCurrentKSTTime(): string {
+  const now = new Date();
+  // UTC → KST (+9시간)
+  const kst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
+  const hours = String(kst.getUTCHours()).padStart(2, "0");
+  const minutes = String(kst.getUTCMinutes()).padStart(2, "0");
+  return `${hours}:${minutes}`;
+}
+
+// Lambda 핸들러 - EventBridge에서 매분 트리거
+export const handler = async (): Promise<void> => {
+  const currentTime = getCurrentKSTTime();
+  console.log(`알림 체크 시작: ${currentTime} KST`);
+
+  try {
+    // 현재 시각과 일치하는 활성 todo 조회
+    const todos = await prisma.telegramTodo.findMany({
+      where: {isActive: true, time: currentTime},
+    });
+
+    if (todos.length === 0) {
+      console.log("발송할 알림 없음");
+      return;
+    }
+
+    console.log(`${todos.length}건 알림 발송 시작`);
+
+    // 각 todo에 대해 메시지 발송
+    const results = await Promise.allSettled(
+      todos.map((todo) => sendMessage(todo.chatId, `🔔 <b>리마인더</b>\n📌 ${todo.title}`))
+    );
+
+    // 결과 로깅
+    const success = results.filter((r) => r.status === "fulfilled" && r.value).length;
+    const failed = results.length - success;
+    console.log(`발송 완료: 성공 ${success}건, 실패 ${failed}건`);
+  } catch (error) {
+    console.error("Lambda 실행 오류:", error);
+    throw error;
+  }
+};

--- a/lambda/telegram-notifier/package.json
+++ b/lambda/telegram-notifier/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "telegram-notifier",
+  "version": "1.0.0",
+  "description": "텔레그램 Todo 알림 Lambda 함수",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "cp ../../prisma/schema.prisma prisma/schema.prisma && npx prisma generate && tsc",
+    "package": "npm run build && cd dist && zip -r ../telegram-notifier.zip . ../node_modules ../prisma"
+  },
+  "dependencies": {
+    "@prisma/client": "^6.7.0"
+  },
+  "devDependencies": {
+    "prisma": "^6.7.0",
+    "typescript": "^5.0.0",
+    "@types/node": "^20.0.0"
+  }
+}

--- a/lambda/telegram-notifier/tsconfig.json
+++ b/lambda/telegram-notifier/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,3 +122,17 @@ model PigMoneySettings {
   user   User @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId Int  @unique
 }
+
+// 텔레그램 Todo 알림
+model TelegramTodo {
+  id        Int      @id @default(autoincrement())
+  chatId    String   // 텔레그램 chat ID
+  title     String   // 할 일 제목
+  time      String   // 알림 시각 "HH:mm" (KST 기준)
+  isActive  Boolean  @default(true) // 활성/비활성 상태
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([chatId])
+  @@index([isActive, time]) // Lambda 스캔 최적화
+}

--- a/src/app/(api)/api/telegram/webhook/[token]/route.ts
+++ b/src/app/(api)/api/telegram/webhook/[token]/route.ts
@@ -1,0 +1,169 @@
+import {NextResponse} from "next/server";
+import {TELEGRAM} from "@/shared/lib/telegram/constants";
+import {parseTodoCommand, parseIndexCommand} from "@/shared/lib/telegram/parser";
+import {sendTelegramMessage} from "@/shared/lib/telegram/bot";
+import {
+  createTelegramTodo,
+  getActiveTodos,
+  completeTodo,
+  deleteTodo,
+} from "@/features/telegram/model/services/telegramTodo.service";
+
+// 텔레그램 Webhook 메시지 타입
+interface TelegramUpdate {
+  message?: {
+    chat: {id: number};
+    text?: string;
+  };
+}
+
+// 허용된 chatId 확인
+function isAllowedChat(chatId: number): boolean {
+  return String(chatId) === process.env.TELEGRAM_ALLOWED_CHAT_ID;
+}
+
+// 사용법 안내 메시지
+const HELP_MESSAGE = `📋 <b>Todo 봇 사용법</b>
+
+<b>등록</b>
+/todo 제목 → 매일 18:10 알림
+/todo 제목 07:30 → 매일 07:30 알림
+/todo 제목 22:00 every → 동일
+
+<b>조회</b>
+/list → 활성 todo 목록
+
+<b>완료/삭제</b>
+/done 번호 → 완료 처리
+/delete 번호 → 삭제
+
+※ 제목은 공백 없이 작성 (예: 계란_사기)`;
+
+export async function POST(
+  request: Request,
+  {params}: {params: Promise<{token: string}>}
+) {
+  const {token} = await params;
+
+  // 1차 보안: URL 토큰 검증
+  if (token !== process.env.TELEGRAM_WEBHOOK_SECRET) {
+    return NextResponse.json({ok: true});
+  }
+
+  try {
+    const update: TelegramUpdate = await request.json();
+    const message = update.message;
+
+    // 메시지가 없거나 텍스트가 없으면 무시
+    if (!message?.text) {
+      return NextResponse.json({ok: true});
+    }
+
+    const chatId = message.chat.id;
+
+    // 2차 보안: chatId 허용 확인
+    if (!isAllowedChat(chatId)) {
+      return NextResponse.json({ok: true});
+    }
+
+    const text = message.text.trim();
+    const chatIdStr = String(chatId);
+
+    // 명령어 분기
+    if (text.startsWith(TELEGRAM.COMMAND.TODO)) {
+      await handleTodoCommand(chatIdStr, text);
+    } else if (text.startsWith(TELEGRAM.COMMAND.LIST)) {
+      await handleListCommand(chatIdStr);
+    } else if (text.startsWith(TELEGRAM.COMMAND.DONE)) {
+      await handleDoneCommand(chatIdStr, text);
+    } else if (text.startsWith(TELEGRAM.COMMAND.DELETE)) {
+      await handleDeleteCommand(chatIdStr, text);
+    } else {
+      // 미인식 명령어 → 사용법 안내
+      await sendTelegramMessage(chatIdStr, HELP_MESSAGE);
+    }
+  } catch (error) {
+    console.error("Webhook 처리 오류:", error);
+  }
+
+  // 항상 200 OK 반환 (텔레그램 재전송 방지)
+  return NextResponse.json({ok: true});
+}
+
+// /todo 명령 처리
+async function handleTodoCommand(chatId: string, text: string) {
+  const parsed = parseTodoCommand(text);
+
+  if (!parsed) {
+    await sendTelegramMessage(chatId, "❌ 형식 오류\n사용법: /todo 제목 [HH:mm] [every]");
+    return;
+  }
+
+  const todo = await createTelegramTodo(chatId, parsed.title, parsed.time);
+  await sendTelegramMessage(
+    chatId,
+    `✅ 등록 완료\n📌 ${todo.title}\n⏰ 매일 ${todo.time}`
+  );
+}
+
+// /list 명령 처리
+async function handleListCommand(chatId: string) {
+  const todos = await getActiveTodos(chatId);
+
+  if (todos.length === 0) {
+    await sendTelegramMessage(chatId, "📭 등록된 todo가 없습니다.");
+    return;
+  }
+
+  const list = todos
+    .map((todo: {title: string; time: string}, i: number) => `${i + 1}. ${todo.title} (⏰ ${todo.time})`)
+    .join("\n");
+
+  await sendTelegramMessage(chatId, `📋 <b>활성 Todo 목록</b>\n\n${list}`);
+}
+
+// /done 명령 처리
+async function handleDoneCommand(chatId: string, text: string) {
+  const parsed = parseIndexCommand(text);
+
+  if (!parsed) {
+    await sendTelegramMessage(chatId, "❌ 형식 오류\n사용법: /done 번호");
+    return;
+  }
+
+  // 번호 → 실제 todo ID 매핑
+  const todos = await getActiveTodos(chatId);
+  const targetIndex = parsed.index - 1;
+
+  if (targetIndex < 0 || targetIndex >= todos.length) {
+    await sendTelegramMessage(chatId, `❌ ${parsed.index}번 todo가 없습니다.`);
+    return;
+  }
+
+  const target = todos[targetIndex];
+  await completeTodo(chatId, target.id);
+  await sendTelegramMessage(chatId, `✔️ 완료: ${target.title}`);
+}
+
+// /delete 명령 처리
+async function handleDeleteCommand(chatId: string, text: string) {
+  const parsed = parseIndexCommand(text);
+
+  if (!parsed) {
+    await sendTelegramMessage(chatId, "❌ 형식 오류\n사용법: /delete 번호");
+    return;
+  }
+
+  // 번호 → 실제 todo ID 매핑
+  const todos = await getActiveTodos(chatId);
+  const targetIndex = parsed.index - 1;
+
+  if (targetIndex < 0 || targetIndex >= todos.length) {
+    await sendTelegramMessage(chatId, `❌ ${parsed.index}번 todo가 없습니다.`);
+    return;
+  }
+
+  const target = todos[targetIndex];
+  await deleteTodo(chatId, target.id);
+  await sendTelegramMessage(chatId, `🗑️ 삭제: ${target.title}`);
+}

--- a/src/features/telegram/model/services/telegramTodo.service.ts
+++ b/src/features/telegram/model/services/telegramTodo.service.ts
@@ -1,0 +1,38 @@
+import db from "@/shared/lib/db";
+
+// Todo 생성
+export async function createTelegramTodo(chatId: string, title: string, time: string) {
+  return db.telegramTodo.create({
+    data: {chatId, title, time},
+  });
+}
+
+// 활성 Todo 목록 조회
+export async function getActiveTodos(chatId: string) {
+  return db.telegramTodo.findMany({
+    where: {chatId, isActive: true},
+    orderBy: {createdAt: "asc"},
+  });
+}
+
+// Todo 완료 처리 (비활성화)
+export async function completeTodo(chatId: string, todoId: number) {
+  return db.telegramTodo.updateMany({
+    where: {id: todoId, chatId},
+    data: {isActive: false},
+  });
+}
+
+// Todo 삭제
+export async function deleteTodo(chatId: string, todoId: number) {
+  return db.telegramTodo.deleteMany({
+    where: {id: todoId, chatId},
+  });
+}
+
+// 특정 시각의 활성 Todo 조회 (Lambda에서 사용)
+export async function getTodosByTime(time: string) {
+  return db.telegramTodo.findMany({
+    where: {isActive: true, time},
+  });
+}

--- a/src/shared/lib/telegram/bot.ts
+++ b/src/shared/lib/telegram/bot.ts
@@ -1,0 +1,51 @@
+import {TELEGRAM} from "./constants";
+
+// 텔레그램 Bot API 토큰
+function getBotToken(): string {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) throw new Error("TELEGRAM_BOT_TOKEN 환경변수가 설정되지 않았습니다.");
+  return token;
+}
+
+// 텔레그램 메시지 발송
+export async function sendTelegramMessage(chatId: string, text: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${TELEGRAM.API_BASE}${getBotToken()}/sendMessage`, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({
+        chat_id: chatId,
+        text,
+        parse_mode: "HTML",
+      }),
+    });
+
+    if (!response.ok) {
+      console.error("텔레그램 메시지 발송 실패:", await response.text());
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error("텔레그램 메시지 발송 오류:", error);
+    return false;
+  }
+}
+
+// 텔레그램 Webhook 설정 (최초 1회 실행용)
+export async function setWebhook(url: string): Promise<boolean> {
+  try {
+    const response = await fetch(`${TELEGRAM.API_BASE}${getBotToken()}/setWebhook`, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({url}),
+    });
+
+    const result = await response.json();
+    console.log("Webhook 설정 결과:", result);
+    return result.ok === true;
+  } catch (error) {
+    console.error("Webhook 설정 오류:", error);
+    return false;
+  }
+}

--- a/src/shared/lib/telegram/constants.ts
+++ b/src/shared/lib/telegram/constants.ts
@@ -1,0 +1,24 @@
+// 텔레그램 봇 관련 상수
+export const TELEGRAM = {
+  // 기본 알림 시각 (KST)
+  DEFAULT_TIME: "18:10",
+
+  // 시간 포맷 패턴 (HH:mm)
+  TIME_PATTERN: /^\d{2}:\d{2}$/,
+
+  // 봇 명령어
+  COMMAND: {
+    TODO: "/todo",
+    LIST: "/list",
+    DONE: "/done",
+    DELETE: "/delete",
+  },
+
+  // 반복 옵션
+  REPEAT: {
+    EVERY: "every",
+  },
+
+  // 텔레그램 Bot API 기본 URL
+  API_BASE: "https://api.telegram.org/bot",
+} as const;

--- a/src/shared/lib/telegram/parser.ts
+++ b/src/shared/lib/telegram/parser.ts
@@ -1,0 +1,64 @@
+import {TELEGRAM} from "./constants";
+
+// 파싱된 todo 명령 결과
+export interface ParsedTodoCommand {
+  title: string;
+  time: string; // "HH:mm"
+}
+
+// 파싱된 done/delete 명령 결과
+export interface ParsedIndexCommand {
+  index: number; // 1-based 번호
+}
+
+// 시간 유효성 검증 (00:00 ~ 23:59)
+function isValidTime(time: string): boolean {
+  if (!TELEGRAM.TIME_PATTERN.test(time)) return false;
+  const [hours, minutes] = time.split(":").map(Number);
+  return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59;
+}
+
+/**
+ * /todo 명령어 파싱
+ * - /todo title → { title, time: "18:10" }
+ * - /todo title 07:30 → { title, time: "07:30" }
+ * - /todo title 22:00 every → { title, time: "22:00" }
+ */
+export function parseTodoCommand(text: string): ParsedTodoCommand | null {
+  const tokens = text.trim().split(/\s+/);
+
+  // 최소 2개 토큰 필요: /todo title
+  if (tokens.length < 2) return null;
+
+  const title = tokens[1];
+
+  // 토큰 2개: /todo title → 기본 시간
+  if (tokens.length === 2) {
+    return {title, time: TELEGRAM.DEFAULT_TIME};
+  }
+
+  // 토큰 3개 이상: 시간 확인
+  const possibleTime = tokens[2];
+  if (TELEGRAM.TIME_PATTERN.test(possibleTime) && isValidTime(possibleTime)) {
+    return {title, time: possibleTime};
+  }
+
+  // 시간 형식이 아니면 기본값 적용
+  return {title, time: TELEGRAM.DEFAULT_TIME};
+}
+
+/**
+ * /done, /delete 명령어 파싱
+ * - /done 3 → { index: 3 }
+ * - /delete 1 → { index: 1 }
+ */
+export function parseIndexCommand(text: string): ParsedIndexCommand | null {
+  const tokens = text.trim().split(/\s+/);
+
+  if (tokens.length < 2) return null;
+
+  const index = parseInt(tokens[1], 10);
+  if (isNaN(index) || index < 1) return null;
+
+  return {index};
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "target": "ES2017"
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "lambda"]
 }


### PR DESCRIPTION
## Summary
- 텔레그램 봇을 통한 Todo 알림 기능 추가
- 사용자가 텔레그램 채팅으로 할 일을 등록하면, 지정 시각에 알림을 받을 수 있음
- Webhook API + AWS Lambda(EventBridge 매분 트리거) 구조로 실시간 명령 처리와 알림 발송을 분리

## Changes

### 데이터 모델
- `TelegramTodo` Prisma 모델 추가 (chatId, title, time, isActive)
- Lambda 스캔 최적화를 위한 복합 인덱스 (`isActive`, `time`)

### 텔레그램 봇 공통 라이브러리 (`src/shared/lib/telegram/`)
- `constants.ts` — 명령어, 기본 알림 시각, API URL 상수 정의
- `bot.ts` — Bot API 메시지 발송 및 Webhook 설정 유틸리티
- `parser.ts` — `/todo`, `/done`, `/delete` 명령어 파서

### Webhook API 엔드포인트
- `POST /api/telegram/webhook/[token]` — 텔레그램 Webhook 수신
- URL 토큰 검증 + chatId 허용 확인 2단계 보안
- `/todo`, `/list`, `/done`, `/delete` 명령어 핸들러 구현

### Todo CRUD 서비스
- Prisma 기반 생성, 조회, 완료, 삭제 서비스 함수
- 시각별 활성 Todo 조회 함수 (Lambda 알림용)

### Lambda 알림 함수 (`lambda/telegram-notifier/`)
- EventBridge 매분 트리거로 현재 KST 시각 기준 알림 발송
- 독립 빌드/패키징 스크립트 구성
- 루트 `tsconfig.json`에서 lambda 디렉토리 exclude 처리

## Architecture

사용자 ↔ 텔레그램 봇
↓ Webhook
Next.js API Route ─→ Prisma ─→ PostgreSQL
↑
AWS Lambda (매분) ──→ Prisma ───────┘
↓
텔레그램 Bot API → 사용자에게 알림

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram bot integration enabling users to create and manage todos through chat commands
  * Support for `/todo` (create), `/list` (view), `/done` (mark complete), and `/delete` commands
  * Automatic notifications delivered via Telegram at user-specified times
  * Todos tracked with active status and creation timestamps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->